### PR TITLE
Sync node and yarn versions with the main repo

### DIFF
--- a/.github/workflows/cbioportal-frontend-publish.yml
+++ b/.github/workflows/cbioportal-frontend-publish.yml
@@ -19,9 +19,9 @@ jobs:
       - run: git fetch origin +refs/tags/*:refs/tags/*
       - uses: actions/setup-node@v1
         with:
-          node-version: '15.2.1'
+          node-version: '22.18.0'
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn policies set-version 1.22.5
+      - run: yarn policies set-version 1.22.22
       - run: yarn --frozen-lockfile
       - run: yarn updatePackageVersion
       - run: yarn buildModules


### PR DESCRIPTION
We recently upgraded node to version 22 (see https://github.com/cBioPortal/cbioportal-frontend/pull/5354)

We need to update the publish action to reflect these changes.